### PR TITLE
Removed --pulp-password from args passed to pubtools-pulp

### DIFF
--- a/pubtools/iib/iib_ops.py
+++ b/pubtools/iib/iib_ops.py
@@ -179,8 +179,6 @@ def _iib_op_main(args, operation=None, items_final_state="PUSHED"):
         args.pulp_url,
         "--pulp-user",
         args.pulp_user,
-        "--pulp-password",
-        args.pulp_password,
         "--repo-ids",
         args.pulp_repository,
     ]


### PR DESCRIPTION
To avoid password exposure, PULP_PASSWORD should be used instead