### PR TITLE
Make bundle an optional input argument [CLOUDDST-2205]

### DIFF
--- a/pubtools/iib/iib_ops.py
+++ b/pubtools/iib/iib_ops.py
@@ -131,7 +131,7 @@ ADD_CMD_ARGS = CMD_ARGS.copy()
 ADD_CMD_ARGS[("--bundle",)] = {
     "group": "IIB service",
     "help": "<hostname>/<namespace>/<image>:<tag> of bundle",
-    "required": True,
+    "required": False,
     "type": str,
     "action": "append",
 }
@@ -229,7 +229,7 @@ def _iib_op_main(args, operation=None, items_final_state="PUSHED"):
     build_details = bundle_op(
         args.index_image,
         args.binary_image,
-        args.bundle if hasattr(args, "bundle") else args.operator,
+        args.bundle if operation == "add_bundles" else args.operator,
         args.arch,
         **extra_args
     )


### PR DESCRIPTION
If no bundles are specified, no exception is raised. Instead, iiblib is called with bundles specified as None.