### PR TITLE
Log link to build details, don't print JSON [CLOUDDST-2404]

### DIFF
--- a/pubtools/iib/iib_ops.py
+++ b/pubtools/iib/iib_ops.py
@@ -251,12 +251,10 @@ def _iib_op_main(args, operation=None, items_final_state="PUSHED"):
             build_details, "NOTPUSHED", args.pulp_repository
         )
         pc.update_push_items(push_items)
-        sys.stderr.write("\n")
         sys.exit(1)
 
     LOG.info("IIB build finished")
     if args.skip_pulp:
-        sys.stdout.write("\n")
         return build_details
 
     LOG.debug("Getting pulp repository: %s", args.pulp_repository)
@@ -296,7 +294,6 @@ def _iib_op_main(args, operation=None, items_final_state="PUSHED"):
     LOG.info("IIB push finished")
     pc.update_push_items(push_items)
 
-    sys.stdout.write("\n")
     return build_details
 
 

--- a/pubtools/iib/iib_ops.py
+++ b/pubtools/iib/iib_ops.py
@@ -312,6 +312,10 @@ def _iib_op_main(args, operation=None, items_final_state="PUSHED"):
         indent=4,
         separators=(",", ": "),
     )
+
+    build_details_url = _make_iib_build_details_url(args.iib_server, build_details.id)
+    LOG.info("IIB details: %s", build_details_url)
+
     sys.stdout.write("\n")
     return build_details
 
@@ -344,3 +348,7 @@ def remove_operators_main(sysargs=None):
     process_parsed_args(args, RM_CMD_ARGS)
 
     return _iib_op_main(args, "remove_operators", "DELETED")
+
+
+def _make_iib_build_details_url(host, task_id):
+    return "https://%s/api/v1/builds/%s" % (host, task_id)

--- a/pubtools/iib/iib_ops.py
+++ b/pubtools/iib/iib_ops.py
@@ -241,31 +241,21 @@ def _iib_op_main(args, operation=None, items_final_state="PUSHED"):
     pc.update_push_items(push_items)
 
     build_details = iib_c.wait_for_build(build_details)
+
+    build_details_url = _make_iib_build_details_url(args.iib_server, build_details.id)
+    LOG.info("IIB details: %s", build_details_url)
+
     if build_details.state == "failed":
         LOG.error("IIB operation failed")
         push_items = push_items_from_build(
             build_details, "NOTPUSHED", args.pulp_repository
         )
         pc.update_push_items(push_items)
-        json.dump(
-            build_details.to_dict(),
-            sys.stderr,
-            sort_keys=True,
-            indent=4,
-            separators=(",", ": "),
-        )
         sys.stderr.write("\n")
         sys.exit(1)
 
     LOG.info("IIB build finished")
     if args.skip_pulp:
-        json.dump(
-            build_details.to_dict(),
-            sys.stdout,
-            sort_keys=True,
-            indent=4,
-            separators=(",", ": "),
-        )
         sys.stdout.write("\n")
         return build_details
 
@@ -305,16 +295,6 @@ def _iib_op_main(args, operation=None, items_final_state="PUSHED"):
     )
     LOG.info("IIB push finished")
     pc.update_push_items(push_items)
-    json.dump(
-        build_details.to_dict(),
-        sys.stdout,
-        sort_keys=True,
-        indent=4,
-        separators=(",", ": "),
-    )
-
-    build_details_url = _make_iib_build_details_url(args.iib_server, build_details.id)
-    LOG.info("IIB details: %s", build_details_url)
 
     sys.stdout.write("\n")
     return build_details

--- a/tests/test_iib_ops.py
+++ b/tests/test_iib_ops.py
@@ -352,6 +352,7 @@ def test_add_bundles_cli_error(
 
 def test_add_bundles_py(
     caplog,
+    capsys,
     fixture_iib_client,
     fixture_pulp_client,
     fixture_iib_krb_auth,
@@ -399,6 +400,10 @@ def test_add_bundles_py(
         FIXTURE_IIB_SERVER, task_id
     )
     assert url_msg in caplog.messages
+
+    # build details should not be dumped into stdout
+    captured = capsys.readouterr()
+    assert '"id": "{}"'.format(task_id) not in captured.out
 
 
 def test_add_bundles_py_multiple_bundles(

--- a/tests/test_iib_ops.py
+++ b/tests/test_iib_ops.py
@@ -401,9 +401,9 @@ def test_add_bundles_py(
     )
     assert url_msg in caplog.messages
 
-    # build details should not be dumped into stdout
+    # neither build details nor anything else dumped into stdout
     captured = capsys.readouterr()
-    assert '"id": "{}"'.format(task_id) not in captured.out
+    assert not captured.out
 
 
 def test_add_bundles_py_multiple_bundles(

--- a/tests/test_iib_ops.py
+++ b/tests/test_iib_ops.py
@@ -1,5 +1,4 @@
 import contextlib
-from copy import deepcopy
 import mock
 import pkg_resources
 import pytest
@@ -16,6 +15,9 @@ from pubtools.pulplib import ContainerImageRepository
 from more_executors.futures import f_return
 
 from utils import FakeTaskManager, FakeCollector
+
+
+FIXTURE_IIB_SERVER = "iib-server"
 
 
 fake_tm = FakeTaskManager()
@@ -141,7 +143,7 @@ def fixture_common_iib_op_args():
         "pulp-user",
         "--pulp-insecure",
         "--iib-server",
-        "iib-server",
+        FIXTURE_IIB_SERVER,
         "--index-image",
         "index-image",
         "--binary-image",
@@ -349,6 +351,7 @@ def test_add_bundles_cli_error(
 
 
 def test_add_bundles_py(
+    caplog,
     fixture_iib_client,
     fixture_pulp_client,
     fixture_iib_krb_auth,
@@ -390,6 +393,12 @@ def test_add_bundles_py(
     assert fixture_pulplib_repo_sync.mock_calls[0].args[0].feed == "https://feed.com"
 
     fixture_pulplib_repo_publish.assert_called_once()
+
+    task_id = retval.id
+    url_msg = "IIB details: https://{}/api/v1/builds/{}".format(
+        FIXTURE_IIB_SERVER, task_id
+    )
+    assert url_msg in caplog.messages
 
 
 def test_add_bundles_py_multiple_bundles(


### PR DESCRIPTION
The pubtools-iib CLI commands used to dump the build details JSON
into stdout. Pub would then call the commands, capture their stdout
and stderr output and add it to its own logs.

Such verbose output is unnecessary because the JSON is available
on the IIB server via HTTP API.

This PR removes the JSON from the logs and replaces it with the URL.