### PR TITLE
Add option of pushing to Quay

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [report]
 show_missing = True
-fail_under = 90
+fail_under = 100
 exclude_lines =
     pragma: no cover
     if __name__ == .__main__.:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[report]
+show_missing = True
+fail_under = 90
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include README.rst
 include LICENSE
 recursive-include docs *.rst conf.py Makefile
 recursive-include pubtools_iib *.py
+include requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ Setup
 Usage
 =====
 
+Push the created index image to Pulp
 ::
 
   $ export PULP_PASSWORD="pulppassword"
@@ -41,6 +42,7 @@ Usage
     --index-image container-registry.example.com/index/image:latest
     --bundle container-registry.example.com/bundle/image:123
     --arch x86_64
+    --skip-quay
 
   $ export PULP_PASSWORD="pulppassword"
   $ pubtools-iib-remove-operators --pulp-url https://pulphost.example.com/\
@@ -51,4 +53,30 @@ Usage
     --index-image container-registry.example.com/index/image:latest
     --operator bundle/image:123
     --arch x86_64
+    --skip-quay
+
+Push the created index image to Quay in a remote server and send a UMB message
+::
+
+  $ export QUAY_PASSWORD=quay_password
+  $ export SSH_PASSWORD=ssh_password
+  $ pubtools-iib-add-bundles \
+    --iib-server iibhostname.example.com \
+    --binary-image container-registry.example.com/binary/image:latest \
+    --index-image container-registry.example.com/index/image:latest \
+    --bundle container-registry.example.com/bundle/image:123 \
+    --arch x86_64 \
+    --skip-pulp \
+    --quay-dest-repo quay.io/namespace/repo \
+    --quay-user namespace+robot_account \
+    --quay-remote-exec \
+    --quay-ssh-remote-host 127.0.0.1 \
+    --quay-ssh-remote-host-port 2222 \
+    --quay-ssh-username ssh_user \
+    --quay-send-umb-msg \
+    --quay-umb-url amqps://umb-url1:5671 \
+    --quay-umb-url amqps://umb-url2:5671 \
+    --quay-umb-cert /path/to/file.crt \
+    --quay-umb-client-key /path/to/file.key \
+    --quay-umb-ca-cert /path/to/cacert.crt
 

--- a/pubtools/iib/iib_ops.py
+++ b/pubtools/iib/iib_ops.py
@@ -9,6 +9,7 @@ from .utils import (
     setup_arg_parser,
     setup_entry_point_cli,
 )
+from iiblib.iib_build_details_model import AddModel
 
 from pubtools import pulplib
 import pushcollector
@@ -20,13 +21,13 @@ CMD_ARGS = {
     ("--pulp-url",): {
         "group": "Pulp environment",
         "help": "Pulp server URL",
-        "required": True,
+        "required": False,
         "type": str,
     },
     ("--pulp-user",): {
         "group": "Pulp environment",
         "help": "Pulp username",
-        "required": True,
+        "required": False,
         "type": str,
     },
     ("--pulp-password",): {
@@ -125,6 +126,112 @@ CMD_ARGS = {
         "required": False,
         "type": bool,
     },
+    ("--skip-quay",): {
+        "group": "IIB service",
+        "help": "Skip pushing to Quay.",
+        "required": False,
+        "type": bool,
+    },
+    ("--quay-dest-repo",): {
+        "group": "IIB service",
+        "help": "Destination repository for push to Quay. Tag will be provided by IIB build.",
+        "required": False,
+        "type": str,
+    },
+    ("--quay-user",): {
+        "group": "IIB service",
+        "help": "Username for Quay login.",
+        "required": False,
+        "type": str,
+    },
+    ("--quay-password",): {
+        "group": "IIB service",
+        "help": "Password for Quay. Can be specified by env variable QUAY_PASSWORD.",
+        "required": False,
+        "type": str,
+        "env_variable": "QUAY_PASSWORD",
+    },
+    ("--quay-remote-exec",): {
+        "group": "IIB service",
+        "help": "Flag of whether the quay tag commands should be executed on a remote server.",
+        "required": False,
+        "type": bool,
+    },
+    ("--quay-ssh-remote-host",): {
+        "group": "IIB service",
+        "help": "Hostname for Quay tag remote execution.",
+        "required": False,
+        "type": str,
+    },
+    ("--quay-ssh-remote-host-port",): {
+        "group": "IIB service",
+        "help": "Port of the remote host",
+        "required": False,
+        "type": int,
+    },
+    ("--quay-ssh-reject-unknown-host",): {
+        "group": "IIB service",
+        "help": "Flag of whether to reject an SSH host when it's not found among known hosts.",
+        "required": False,
+        "type": bool,
+    },
+    ("--quay-ssh-username",): {
+        "group": "IIB service",
+        "help": "Username for SSH connection. Defaults to local username.",
+        "required": False,
+        "type": str,
+    },
+    ("--quay-ssh-password",): {
+        "group": "IIB service",
+        "help": "Password for SSH. Will only be used if key-based validation is not available. "
+        "Can be specified by env variable SSH_PASSWORD",
+        "required": False,
+        "type": str,
+        "env_variable": "SSH_PASSWORD",
+    },
+    ("--quay-ssh-key-filename",): {
+        "group": "IIB service",
+        "help": "Path to the private key file for SSH authentication.",
+        "required": False,
+        "type": str,
+    },
+    ("--quay-send-umb-msg",): {
+        "group": "IIB service",
+        "help": "Flag of whether to send a UMB message after performing a Quay push",
+        "required": False,
+        "type": bool,
+    },
+    ("--quay-umb-url",): {
+        "group": "IIB service",
+        "help": "UMB URL. More than one can be specified.",
+        "required": False,
+        "type": str,
+        "action": "append",
+    },
+    ("--quay-umb-cert",): {
+        "group": "IIB service",
+        "help": "Path to the UMB certificate for SSL authentication.",
+        "required": False,
+        "type": str,
+    },
+    ("--quay-umb-client-key",): {
+        "group": "IIB service",
+        "help": "Path to the UMB private key for accessing the certificate.",
+        "required": False,
+        "type": str,
+    },
+    ("--quay-umb-ca-cert",): {
+        "group": "IIB service",
+        "help": "Path to the UMB CA certificate.",
+        "required": False,
+        "type": str,
+    },
+    ("--quay-umb-topic",): {
+        "group": "IIB service",
+        "help": "UMB topic to send the message to.",
+        "required": False,
+        "type": str,
+    },
 }
 
 ADD_CMD_ARGS = CMD_ARGS.copy()
@@ -152,7 +259,7 @@ RM_CMD_ARGS[("--operator",)] = {
 }
 
 
-def push_items_from_build(build_details, state, pulp_repository):
+def push_items_from_build(build_details, state, destination_repository):
     ret = []
     if build_details.request_type == "add":
         for operator, bundles in build_details.bundle_mapping.items():
@@ -162,7 +269,7 @@ def push_items_from_build(build_details, state, pulp_repository):
                     "origin": build_details.from_index or "scratch",
                     "src": bundle,
                     "filename": operator,
-                    "dest": pulp_repository,
+                    "dest": destination_repository,
                     "build": build_details.index_image,
                     "signing_key": None,
                     "checksums": None,
@@ -175,7 +282,7 @@ def push_items_from_build(build_details, state, pulp_repository):
                 "origin": build_details.from_index or "scratch",
                 "src": None,
                 "filename": operator,
-                "dest": pulp_repository,
+                "dest": destination_repository,
                 "build": build_details.index_image,
                 "signing_key": None,
                 "checksums": None,
@@ -198,6 +305,209 @@ def process_parsed_args(parsed_args, args):
                     parsed_args, named_alias, os.environ.get(arg_data["env_variable"])
                 )
     return parsed_args
+
+
+def validate_args(args, operation=None):
+    """
+    Validate the correctness of input arguments.
+
+    Args:
+        args (argparse.Namespace):
+            Arguments from the command line
+        operation (str):
+            Type of operation performed. Can be 'add_bundles' or 'remove_operators'.
+    """
+
+    if not args.skip_pulp and args.skip_quay:
+        if not args.pulp_url:
+            raise ValueError("If pushing to Pulp, '--pulp-url' must be specified.")
+        if not args.pulp_user:
+            raise ValueError("If pushing to Pulp, '--pulp-user' must be specified.")
+        if not args.pulp_password:
+            raise ValueError(
+                "If pushing to Pulp, '--pulp-password' must be specified "
+                "(or via PULP_PASSWORD env variable)."
+            )
+
+    if not args.skip_quay:
+        if not args.quay_dest_repo:
+            raise ValueError("If pushing to Quay, destination repo must be specified.")
+        if ":" in args.quay_dest_repo:
+            raise ValueError(
+                "Quay destination repo contains a tag or digest. "
+                "Please specify only a repo."
+            )
+        if (args.quay_user and not args.quay_password) or (
+            args.quay_password and not args.quay_user
+        ):
+            raise ValueError(
+                "Both Quay user and password must be present when attempting to log in."
+            )
+        if args.quay_remote_exec and not args.quay_ssh_remote_host:
+            raise ValueError(
+                "Remote host is missing when remote execution was specified."
+            )
+        if args.quay_send_umb_msg and not args.quay_umb_url:
+            raise ValueError(
+                "UMB URL must be specified if sending a UMB message was requested (for Quay push)."
+            )
+        if args.quay_send_umb_msg and not args.quay_umb_cert:
+            raise ValueError(
+                "A path to a client certificate must be provided "
+                "when sending a UMB message. (for Quay push)."
+            )
+
+
+def make_pubtools_quay_args(args, build_details):
+    """
+    Construct a pubtools-quay command containing all the necessary arguments.
+
+    Args:
+        args (argparse.Namespace):
+            Input command line arguments.
+        build_details (IIBBuildDetailsModel):
+            Details of IIB build.
+    Return ((list, dict)):
+        Tuple of command line arguments and environment variable arguments
+    """
+    _, tag = build_details.index_image.split(":", 1)
+    dest_image = "{0}:{1}".format(args.quay_dest_repo, tag)
+
+    cmd_args = [
+        "--source-ref",
+        build_details.index_image,
+        "--dest-ref",
+        dest_image,
+        "--all-arch",
+    ]
+    if args.quay_user:
+        cmd_args += ["--quay-user", args.quay_user]
+    if args.quay_remote_exec:
+        cmd_args.append("--remote-exec")
+    if args.quay_ssh_remote_host:
+        cmd_args += ["--ssh-remote-host", args.quay_ssh_remote_host]
+    if args.quay_ssh_remote_host_port:
+        cmd_args += ["--ssh-remote-host-port", str(args.quay_ssh_remote_host_port)]
+    if args.quay_ssh_reject_unknown_host:
+        cmd_args.append("--ssh-reject-unknown-host")
+    if args.quay_ssh_username:
+        cmd_args += ["--ssh-username", args.quay_ssh_username]
+    if args.quay_ssh_key_filename:
+        cmd_args += ["--ssh-key-filename", args.quay_ssh_key_filename]
+    if args.quay_send_umb_msg:
+        cmd_args.append("--send-umb-msg")
+    if args.quay_umb_url:
+        umb_urls = (
+            args.quay_umb_url
+            if isinstance(args.quay_umb_url, list)
+            else [args.quay_umb_url]
+        )
+        for umb_url in umb_urls:
+            cmd_args += ["--umb-url", umb_url]
+    if args.quay_umb_cert:
+        cmd_args += ["--umb-cert", args.quay_umb_cert]
+    if args.quay_umb_client_key:
+        cmd_args += ["--umb-client-key", args.quay_umb_client_key]
+    if args.quay_umb_ca_cert:
+        cmd_args += ["--umb-ca-cert", args.quay_umb_ca_cert]
+    if args.quay_umb_topic:
+        cmd_args += ["--umb-topic", args.quay_umb_topic]
+
+    env_args = {}
+    if args.quay_password:
+        env_args["QUAY_PASSWORD"] = args.quay_password
+    if args.quay_ssh_password:
+        env_args["SSH_PASSWORD"] = args.quay_ssh_password
+
+    return (cmd_args, env_args)
+
+
+def push_to_pulp(args, pulp_c, build_details, pc, items_final_state):
+    """
+    Push the created index image to pulp.
+
+    Args:
+        args (argparse.Namespace):
+            Input command line arguments.
+        pulp_c (pulplib.Client):
+            Pulp client instance.
+        build_details (IIBBuildDetailsModel):
+            Details of IIB build.
+        pc (pushcollector.Collector):
+            Push collector instance.
+        items_final_state (str):
+            Final state of the items.
+    """
+    LOG.debug("Getting pulp repository: %s", args.pulp_repository)
+    container_repo = pulp_c.get_repository(args.pulp_repository)
+    feed, path = build_details.index_image.split("/", 1)
+    upstream_name, tag = path.split(":")
+    LOG.info("Syncing pulp repository with %s", build_details.index_image)
+    container_repo.sync(
+        pulplib.ContainerSyncOptions(
+            feed="https://%s" % feed, upstream_name=upstream_name, tags=[tag]
+        )
+    ).result()
+    LOG.info("Publishing repository %s", args.pulp_repository)
+    publish_args = [
+        "--pulp-url",
+        args.pulp_url,
+        "--pulp-user",
+        args.pulp_user,
+        "--repo-ids",
+        args.pulp_repository,
+    ]
+    env_args = {"PULP_PASSWORD": args.pulp_password}
+    if args.pulp_insecure:
+        publish_args.append("--pulp-insecure")
+
+    with setup_entry_point_cli(
+        ("pubtools-pulp", "console_scripts", "pubtools-pulp-publish"),
+        "pubtools-pulp-publish",
+        publish_args,
+        env_args,
+    ) as entry_func:
+        entry_func()
+
+    push_items = push_items_from_build(
+        build_details, items_final_state, args.pulp_repository
+    )
+    LOG.info("IIB push to pulp finished")
+    pc.update_push_items(push_items)
+
+
+def push_to_quay(args, build_details, pc, items_final_state):
+    """
+    Push the created index image to Quay.
+
+    Args:
+        args (argparse.Namespace):
+            Input command line arguments.
+        build_details (IIBBuildDetailsModel):
+            Details of IIB build.
+        pc (pushcollector.Collector):
+            Push collector instance.
+        items_final_state (str):
+            Final state of the items.
+    """
+    LOG.debug("Pushing image to Quay repository: %s", args.quay_dest_repo)
+    _, tag = build_details.index_image.split(":", 1)
+    dest_image = "{0}:{1}".format(args.quay_dest_repo, tag)
+    tag_args, env_args = make_pubtools_quay_args(args, build_details)
+
+    with setup_entry_point_cli(
+        ("pubtools-quay", "console_scripts", "pubtools-quay-tag-image"),
+        "pubtools-quay-tag-image",
+        tag_args,
+        env_args,
+    ) as entry_func:
+        entry_func()
+
+    push_items = push_items_from_build(
+        build_details, items_final_state, args.quay_dest_repo
+    )
+    LOG.info("IIB push to quay finished")
+    pc.update_push_items(push_items)
 
 
 def _iib_op_main(args, operation=None, items_final_state="PUSHED"):
@@ -236,7 +546,10 @@ def _iib_op_main(args, operation=None, items_final_state="PUSHED"):
         **extra_args
     )
 
-    push_items = push_items_from_build(build_details, "PENDING", args.pulp_repository)
+    destination_repository = (
+        args.pulp_repository if args.skip_quay else args.quay_dest_repo
+    )
+    push_items = push_items_from_build(build_details, "PENDING", destination_repository)
     LOG.debug("Updating push items")
     pc.update_push_items(push_items)
 
@@ -248,51 +561,20 @@ def _iib_op_main(args, operation=None, items_final_state="PUSHED"):
     if build_details.state == "failed":
         LOG.error("IIB operation failed")
         push_items = push_items_from_build(
-            build_details, "NOTPUSHED", args.pulp_repository
+            build_details, "NOTPUSHED", destination_repository
         )
         pc.update_push_items(push_items)
         sys.exit(1)
 
     LOG.info("IIB build finished")
-    if args.skip_pulp:
+    # If both pulp and quay are enabled, only push to quay
+    if not args.skip_quay:
+        push_to_quay(args, build_details, pc, items_final_state)
         return build_details
 
-    LOG.debug("Getting pulp repository: %s", args.pulp_repository)
-    container_repo = pulp_c.get_repository(args.pulp_repository)
-    feed, path = build_details.index_image.split("/", 1)
-    upstream_name, tag = path.split(":")
-    LOG.info("Syncing pulp repository with %s", build_details.index_image)
-    container_repo.sync(
-        pulplib.ContainerSyncOptions(
-            feed="https://%s" % feed, upstream_name=upstream_name, tags=[tag]
-        )
-    ).result()
-    LOG.info("Publishing repository %s", args.pulp_repository)
-    publish_args = [
-        "--pulp-url",
-        args.pulp_url,
-        "--pulp-user",
-        args.pulp_user,
-        "--repo-ids",
-        args.pulp_repository,
-    ]
-    env_args = {"PULP_PASSWORD": args.pulp_password}
-    if args.pulp_insecure:
-        publish_args.append("--pulp-insecure")
-
-    with setup_entry_point_cli(
-        ("pubtools-pulp", "console_scripts", "pubtools-pulp-publish"),
-        "pubtools-pulp-publish",
-        publish_args,
-        env_args,
-    ) as entry_func:
-        entry_func()
-
-    push_items = push_items_from_build(
-        build_details, items_final_state, args.pulp_repository
-    )
-    LOG.info("IIB push finished")
-    pc.update_push_items(push_items)
+    if not args.skip_pulp:
+        push_to_pulp(args, pulp_c, build_details, pc, items_final_state)
+        return build_details
 
     return build_details
 
@@ -312,6 +594,7 @@ def add_bundles_main(sysargs=None):
     else:
         args = parser.parse_args()
     process_parsed_args(args, ADD_CMD_ARGS)
+    validate_args(args, "add_bundles")
 
     return _iib_op_main(args, "add_bundles")
 
@@ -323,6 +606,7 @@ def remove_operators_main(sysargs=None):
     else:
         args = parser.parse_args()
     process_parsed_args(args, RM_CMD_ARGS)
+    validate_args(args, "remove_operators")
 
     return _iib_op_main(args, "remove_operators", "DELETED")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pushcollector
 pubtools-pulp
 iiblib>=0.13.0
 pubtools-pulplib
+pubtools-quay

--- a/setup.py
+++ b/setup.py
@@ -49,11 +49,11 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-INSTALL_REQURIES = ["setuptools", "pubtools-pulplib", "pubtools-pulp", "iiblib"]
+def get_requirements():
+    with open("requirements.txt") as f:
+        return f.read().splitlines()
 
-DEPENDENCY_LINKS = [
-    "git+https://gitlab.cee.redhat.com/jluza/iiblib.git@master#egg=iiblib",
-]
+DEPENDENCY_LINKS = []
 
 
 long_description = read_content("README.rst") + read_content(
@@ -75,7 +75,7 @@ setup(
     classifiers=classifiers,
     packages=find_packages(exclude=["tests"]),
     data_files=[],
-    install_requires=INSTALL_REQURIES,
+    install_requires=get_requirements(),
     dependency_links=DEPENDENCY_LINKS,
     entry_points={
         "console_scripts": [

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,0 +1,405 @@
+import mock
+import pytest
+
+from pubtools.iib import iib_ops
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_basic_passed(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--skip-quay",
+        "--skip-pulp",
+    ]
+    iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+    called_args, _ = mock_main.call_args
+
+    assert called_args[0].iib_server == "some-server.com"
+    assert called_args[0].iib_krb_principal == "some-name"
+    assert called_args[0].bundle == ["some-bundle"]
+    assert called_args[0].skip_quay
+    assert called_args[0].skip_pulp
+
+    iib_ops.remove_operators_main(required_args + ["--operator", "some-operator"])
+    called_args, _ = mock_main.call_args
+
+    assert called_args[0].iib_server == "some-server.com"
+    assert called_args[0].iib_krb_principal == "some-name"
+    assert called_args[0].operator == ["some-operator"]
+    assert called_args[0].skip_quay
+    assert called_args[0].skip_pulp
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_missing_operator(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--skip-quay",
+        "--skip-pulp",
+    ]
+
+    with pytest.raises(SystemExit) as system_error:
+        iib_ops.remove_operators_main(required_args)
+
+    assert system_error.type == SystemExit
+    assert system_error.value.code == 2
+    mock_main.assert_not_called()
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_pulp_success(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--skip-quay",
+        "--pulp-url",
+        "pulp-url.com",
+        "--pulp-user",
+        "some-user",
+        "--pulp-password",
+        "some-password",
+        "--pulp-repository",
+        "some-repository",
+    ]
+    iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+    called_args, _ = mock_main.call_args
+
+    assert called_args[0].iib_server == "some-server.com"
+    assert called_args[0].iib_krb_principal == "some-name"
+    assert called_args[0].bundle == ["some-bundle"]
+    assert called_args[0].skip_quay
+    assert not called_args[0].skip_pulp
+    assert called_args[0].pulp_url == "pulp-url.com"
+    assert called_args[0].pulp_user == "some-user"
+    assert called_args[0].pulp_password == "some-password"
+    assert called_args[0].pulp_repository == "some-repository"
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_pulp_missing_url(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--skip-quay",
+        "--pulp-user",
+        "some-user",
+        "--pulp-password",
+        "some-password",
+        "--pulp-repository",
+        "some-repository",
+    ]
+    with pytest.raises(ValueError, match="If pushing to Pulp, '--pulp-url'.*"):
+        iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_pulp_missing_user(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--skip-quay",
+        "--pulp-url",
+        "pulp-url.com",
+        "--pulp-password",
+        "some-password",
+        "--pulp-repository",
+        "some-repository",
+    ]
+    with pytest.raises(ValueError, match="If pushing to Pulp, '--pulp-user'.*"):
+        iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_pulp_missing_password(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--skip-quay",
+        "--pulp-url",
+        "pulp-url.com",
+        "--pulp-user",
+        "some-user",
+        "--pulp-repository",
+        "some-repository",
+    ]
+    with pytest.raises(ValueError, match="If pushing to Pulp, '--pulp-password'.*"):
+        iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_quay_success(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--skip-pulp",
+        "--quay-dest-repo",
+        "some-repo",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-remote-exec",
+        "--quay-ssh-remote-host",
+        "some-host",
+        "--quay-send-umb-msg",
+        "--quay-umb-url",
+        "some-umb-url:5555",
+        "--quay-umb-cert",
+        "/some/path.crt",
+    ]
+    iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+    called_args, _ = mock_main.call_args
+    print(called_args[0])
+
+    assert called_args[0].iib_server == "some-server.com"
+    assert called_args[0].iib_krb_principal == "some-name"
+    assert called_args[0].bundle == ["some-bundle"]
+    assert called_args[0].skip_pulp
+    assert not called_args[0].skip_quay
+    assert called_args[0].quay_user == "some-user"
+    assert called_args[0].quay_password == "some-password"
+    assert called_args[0].quay_remote_exec
+    assert called_args[0].quay_ssh_remote_host == "some-host"
+    assert called_args[0].quay_send_umb_msg
+    assert called_args[0].quay_umb_url == ["some-umb-url:5555"]
+    assert called_args[0].quay_umb_cert == "/some/path.crt"
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_quay_success_not_skip_pulp(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--quay-dest-repo",
+        "some-repo",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-remote-exec",
+        "--quay-ssh-remote-host",
+        "some-host",
+        "--quay-send-umb-msg",
+        "--quay-umb-url",
+        "some-umb-url:5555",
+        "--quay-umb-cert",
+        "/some/path.crt",
+    ]
+    iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+    called_args, _ = mock_main.call_args
+
+    assert called_args[0].iib_server == "some-server.com"
+    assert called_args[0].iib_krb_principal == "some-name"
+    assert called_args[0].bundle == ["some-bundle"]
+    assert not called_args[0].skip_pulp
+    assert not called_args[0].skip_quay
+    assert called_args[0].quay_user == "some-user"
+    assert called_args[0].quay_password == "some-password"
+    assert called_args[0].quay_remote_exec
+    assert called_args[0].quay_ssh_remote_host == "some-host"
+    assert called_args[0].quay_send_umb_msg
+    assert called_args[0].quay_umb_url == ["some-umb-url:5555"]
+    assert called_args[0].quay_umb_cert == "/some/path.crt"
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_quay_fail_missing_quay_dest_ref(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-remote-exec",
+        "--quay-ssh-remote-host",
+        "some-host",
+        "--quay-send-umb-msg",
+        "--quay-umb-url",
+        "some-umb-url:5555",
+        "--quay-umb-cert",
+        "/some/path.crt",
+    ]
+    with pytest.raises(ValueError, match="If pushing to Quay, destination.*"):
+        iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_quay_fail_wrong_quay_dest_ref(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--quay-dest-repo",
+        "some-repo:1",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-remote-exec",
+        "--quay-ssh-remote-host",
+        "some-host",
+        "--quay-send-umb-msg",
+        "--quay-umb-url",
+        "some-umb-url:5555",
+        "--quay-umb-cert",
+        "/some/path.crt",
+    ]
+    with pytest.raises(ValueError, match="Quay destination repo contains a tag.*"):
+        iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_quay_fail_missing_user(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--quay-dest-repo",
+        "some-repo",
+        "--quay-password",
+        "some-password",
+        "--quay-remote-exec",
+        "--quay-ssh-remote-host",
+        "some-host",
+        "--quay-send-umb-msg",
+        "--quay-umb-url",
+        "some-umb-url:5555",
+        "--quay-umb-cert",
+        "/some/path.crt",
+    ]
+    with pytest.raises(ValueError, match="Both Quay user and password.*"):
+        iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_quay_fail_missing_password(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--quay-dest-repo",
+        "some-repo",
+        "--quay-user",
+        "some-user",
+        "--quay-remote-exec",
+        "--quay-ssh-remote-host",
+        "some-host",
+        "--quay-send-umb-msg",
+        "--quay-umb-url",
+        "some-umb-url:5555",
+        "--quay-umb-cert",
+        "/some/path.crt",
+    ]
+    with pytest.raises(ValueError, match="Both Quay user and password.*"):
+        iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_quay_fail_missing_ssh_remote_host(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--quay-dest-repo",
+        "some-repo",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-remote-exec",
+        "--quay-send-umb-msg",
+        "--quay-umb-url",
+        "some-umb-url:5555",
+        "--quay-umb-cert",
+        "/some/path.crt",
+    ]
+    with pytest.raises(ValueError, match="Remote host is missing.*"):
+        iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_quay_fail_missing_umb_url(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--quay-dest-repo",
+        "some-repo",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-remote-exec",
+        "--quay-ssh-remote-host",
+        "some-host",
+        "--quay-send-umb-msg",
+        "--quay-umb-cert",
+        "/some/path.crt",
+    ]
+    with pytest.raises(ValueError, match="UMB URL must be specified.*"):
+        iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])
+
+
+@mock.patch("pubtools.iib.iib_ops._iib_op_main")
+def test_arg_validation_push_to_quay_fail_missing_umb_cert(mock_main):
+    required_args = [
+        "dummy",
+        "--iib-server",
+        "some-server.com",
+        "--iib-krb-principal",
+        "some-name",
+        "--quay-dest-repo",
+        "some-repo",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-remote-exec",
+        "--quay-ssh-remote-host",
+        "some-host",
+        "--quay-send-umb-msg",
+        "--quay-umb-url",
+        "some-umb-url:5555",
+    ]
+    with pytest.raises(ValueError, match="A path to a client certificate.*"):
+        iib_ops.add_bundles_main(required_args + ["--bundle", "some-bundle"])

--- a/tests/test_iib_ops.py
+++ b/tests/test_iib_ops.py
@@ -36,6 +36,10 @@ operator_1_push_item_notpushed = operator_1_push_item_pending.copy()
 operator_1_push_item_notpushed["state"] = "NOTPUSHED"
 operator_1_push_item_pushed = operator_1_push_item_pending.copy()
 operator_1_push_item_pushed["state"] = "PUSHED"
+operator_quay_push_item_pending = operator_1_push_item_pending.copy()
+operator_quay_push_item_pending["dest"] = "some-repo"
+operator_quay_push_item_pushed = operator_quay_push_item_pending.copy()
+operator_quay_push_item_pushed["state"] = "PUSHED"
 
 operator_1_push_item_delete_pending = {
     "state": "PENDING",
@@ -135,6 +139,12 @@ def fixture_container_image_repo():
 
 
 @pytest.fixture
+def fixture_pubtools_quay():
+    with mock.patch("pubtools._quay.tag_images.tag_images") as quay_patched:
+        yield quay_patched
+
+
+@pytest.fixture
 def fixture_common_iib_op_args():
     return [
         "--pulp-url",
@@ -154,6 +164,37 @@ def fixture_common_iib_op_args():
         "example@REALM",
         "--iib-insecure",
         "--overwrite-from-index",
+    ]
+
+
+@pytest.fixture
+def fixture_push_to_quay_args():
+    return [
+        "--quay-dest-repo",
+        "some-repo",
+        "--quay-user",
+        "some-user",
+        "--quay-remote-exec",
+        "--quay-ssh-remote-host",
+        "some-host",
+        "--quay-ssh-remote-host-port",
+        "2222",
+        "--quay-ssh-reject-unknown-host",
+        "--quay-ssh-username",
+        "ssh-user",
+        "--quay-ssh-key-filename",
+        "/path/to/ssh/file.crt",
+        "--quay-send-umb-msg",
+        "--quay-umb-url",
+        "some-umb-url:5555",
+        "--quay-umb-cert",
+        "/some/path.crt",
+        "--quay-umb-client-key",
+        "/some/path.key",
+        "--quay-umb-ca-cert",
+        "some/cacert.crt",
+        "--quay-umb-topic",
+        "some-topic",
     ]
 
 
@@ -285,7 +326,7 @@ def test_add_bundles_cli(
         ("pubtools_iib", "console_scripts", "pubtools-iib-add-bundles"),
         "pubtools-iib-add-bundle",
         fixture_common_iib_op_args
-        + ["--bundle", "bundle1", "--iib-legacy-org", "legacy-org"]
+        + ["--bundle", "bundle1", "--iib-legacy-org", "legacy-org", "--skip-quay"]
         + extra_args,
         {
             "PULP_PASSWORD": "pulp-password",
@@ -331,7 +372,7 @@ def test_add_bundles_cli_error(
     with setup_entry_point_cli(
         ("pubtools_iib", "console_scripts", "pubtools-iib-add-bundles"),
         "pubtools-iib-add-bundle",
-        fixture_common_iib_op_args + ["--bundle", "bundle1"],
+        fixture_common_iib_op_args + ["--bundle", "bundle1", "--skip-quay"],
         {
             "PULP_PASSWORD": "pulp-password",
             "CNR_TOKEN": "cnr_token",
@@ -373,7 +414,9 @@ def test_add_bundles_py(
         },
     ) as entry_func:
         retval = entry_func(
-            ["cmd"] + fixture_common_iib_op_args + ["--bundle", "bundle1"]
+            ["cmd"]
+            + fixture_common_iib_op_args
+            + ["--bundle", "bundle1", "--skip-quay"]
         )
 
     assert isinstance(retval, IIBBuildDetailsModel)
@@ -430,7 +473,7 @@ def test_add_bundles_py_multiple_bundles(
         retval = entry_func(
             ["cmd"]
             + fixture_common_iib_op_args
-            + ["--bundle", "bundle1", "--bundle", "bundle2"]
+            + ["--bundle", "bundle1", "--bundle", "bundle2", "--skip-quay"]
         )
 
     assert isinstance(retval, IIBBuildDetailsModel)
@@ -495,7 +538,7 @@ def test_remove_operators_cli(
     with setup_entry_point_cli(
         ("pubtools_iib", "console_scripts", "pubtools-iib-remove-operators"),
         "pubtools-iib-remove-operators",
-        fixture_common_iib_op_args + ["--operator", "1"] + extra_args,
+        fixture_common_iib_op_args + ["--operator", "1", "--skip-quay"] + extra_args,
         {
             "PULP_PASSWORD": "pulp-password",
             "OVERWRITE_FROM_INDEX_TOKEN": "overwrite_from_index_token",
@@ -539,7 +582,7 @@ def test_remove_operators_cli_error(
     with setup_entry_point_cli(
         ("pubtools_iib", "console_scripts", "pubtools-iib-remove-operators"),
         "pubtools-iib-remove-operators",
-        fixture_common_iib_op_args + ["--operator", "1"],
+        fixture_common_iib_op_args + ["--operator", "1", "--skip-quay"],
         {
             "PULP_PASSWORD": "pulp-password",
             "OVERWRITE_FROM_INDEX_TOKEN": "overwrite_from_index_token",
@@ -577,7 +620,9 @@ def test_remove_operators_py(
             "OVERWRITE_FROM_INDEX_TOKEN": "overwrite_from_index_token",
         },
     ) as entry_func:
-        retval = entry_func(["cmd"] + fixture_common_iib_op_args + ["--operator", "1"])
+        retval = entry_func(
+            ["cmd"] + fixture_common_iib_op_args + ["--operator", "1", "--skip-quay"]
+        )
 
     assert isinstance(retval, IIBBuildDetailsModel)
 
@@ -595,3 +640,94 @@ def test_invalid_op(fixture_common_iib_op_args):
         assert False, "Should have raised"
     except ValueError:
         pass
+
+
+def test_add_bundles_push_to_quay_all_args(
+    caplog,
+    capsys,
+    fixture_iib_client,
+    fixture_pulp_client,
+    fixture_iib_krb_auth,
+    fixture_pulplib_repo_publish,
+    fixture_pulplib_repo_sync,
+    fixture_container_image_repo,
+    fixture_common_iib_op_args,
+    fixture_push_to_quay_args,
+    fixture_pubtools_quay,
+    fixture_pushcollector,
+):
+
+    repo = fixture_container_image_repo
+    fixture_pulp_client.return_value.search_repository.return_value = [repo]
+    fixture_pulp_client.return_value.get_repository.return_value = repo
+    with setup_entry_point_py(
+        ("pubtools_iib", "console_scripts", "pubtools-iib-add-bundles"),
+        {
+            "PULP_PASSWORD": "pulp-password",
+            "CNR_TOKEN": "cnr_token",
+            "OVERWRITE_FROM_INDEX_TOKEN": "overwrite_from_index_token",
+            "QUAY_PASSWORD": "quay-password",
+            "SSH_PASSWORD": "ssh-password",
+        },
+    ) as entry_func:
+        # --skip-pulp not specified
+        retval = entry_func(
+            ["cmd"]
+            + fixture_common_iib_op_args
+            + ["--bundle", "bundle1"]
+            + fixture_push_to_quay_args
+        )
+
+    assert isinstance(retval, IIBBuildDetailsModel)
+
+    fixture_iib_client.assert_called_once_with(
+        "iib-server", auth=fixture_iib_krb_auth.return_value, ssl_verify=False
+    )
+    fixture_iib_client.return_value.add_bundles.assert_called_once_with(
+        "index-image",
+        ["bundle1"],
+        ["arch"],
+        cnr_token="cnr_token",
+        binary_image="binary-image",
+        overwrite_from_index=True,
+        overwrite_from_index_token="overwrite_from_index_token",
+    )
+    fixture_pulplib_repo_sync.assert_not_called()
+    fixture_pulplib_repo_publish.assert_not_called()
+
+    task_id = retval.id
+    url_msg = "IIB details: https://{}/api/v1/builds/{}".format(
+        FIXTURE_IIB_SERVER, task_id
+    )
+    assert url_msg in caplog.messages
+
+    # neither build details nor anything else dumped into stdout
+    captured = capsys.readouterr()
+    assert not captured.out
+
+    fixture_pubtools_quay.assert_called_once()
+    called_args = fixture_pubtools_quay.call_args[0][0]
+    assert called_args.source_ref == "feed.com/index/image:tag"
+    assert called_args.dest_ref == ["some-repo:tag"]
+    assert called_args.all_arch
+    assert called_args.quay_user == "some-user"
+    assert called_args.quay_password == "quay-password"
+    assert called_args.remote_exec
+    assert called_args.ssh_remote_host == "some-host"
+    assert called_args.ssh_remote_host_port == 2222
+    assert called_args.ssh_reject_unknown_host
+    assert called_args.ssh_username == "ssh-user"
+    assert called_args.ssh_password == "ssh-password"
+    assert called_args.ssh_key_filename == "/path/to/ssh/file.crt"
+    assert called_args.send_umb_msg
+    assert called_args.umb_url == ["some-umb-url:5555"]
+    assert called_args.umb_cert == "/some/path.crt"
+    assert called_args.umb_client_key == "/some/path.key"
+    assert called_args.umb_ca_cert == "some/cacert.crt"
+    assert called_args.umb_topic == "some-topic"
+
+    print(fixture_pushcollector.items)
+    assert fixture_pushcollector.items == [
+        operator_quay_push_item_pending,
+        operator_quay_push_item_pushed,
+    ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,19 +30,24 @@ class FakeTaskManager(object):
             "state_reason": "state_reason",
             "state_history": [],
             "from_index": index,
+            "bundles": map_or_op,
             "from_index_resolved": index + "-resolved",
             "binary_image": binary_image,
             "binary_image_resolved": binary_image + "-resolved",
             "bundle_mapping": {},
             "index_image": "feed.com/index/image:tag",
             "arches": arches,
+            "batch": 123,
+            "updated": "2020-05-26T19:33:58.759687Z",
+            "user": "tbrady@DOMAIN.LOCAL",
+            "removed_operators": ["operator-%s" % k for k in map_or_op],
+            "organization": None,
+            "omps_operator_version": {},
+            "distribution_scope": "",
         }
 
         if op_type == "rm":
             self.tasks[tid]["request_type"] = "rm"
-            self.tasks[tid]["removed_operators"] = [
-                "operator-%s" % k for k in map_or_op
-            ]
         if op_type == "add":
             self.tasks[tid]["request_type"] = "add"
             self.tasks[tid]["bundle_mapping"] = {"operator-1": map_or_op}

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ deps=
 basepython = python3.7
 commands =
     pycodestyle --config=.pycodestyle --first pubtools
-	black --check .
+	black --check --diff pubtools tests
 exclude=.svn,cvs,.bzr,.hg,.git,__pycache__,.tox,setup.py,docs
 
 [testenv:pydocstyle]


### PR DESCRIPTION
If neither --skip-quay nor --skip-pulp is specified, only a push
to Quay is performed. Pubtools-quay is used for pushing to Quay.