### PR TITLE
Fix logger per pubtools conventions

### DIFF
--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -3,6 +3,7 @@ ChangeLog
 
 Unreleased
 -----------
+* Use pubtools.iib logger rather than root logger
 
 0.20.0 (2021-06-10)
 -------------------

--- a/pubtools/iib/iib_ops.py
+++ b/pubtools/iib/iib_ops.py
@@ -13,8 +13,8 @@ from .utils import (
 from pubtools import pulplib
 import pushcollector
 
-LOG = logging.getLogger()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.iib")
+
 
 CMD_ARGS = {
     ("--pulp-url",): {
@@ -314,6 +314,8 @@ def make_rm_operators_parser():
 
 
 def add_bundles_main(sysargs=None):
+    logging.basicConfig(level=logging.INFO)
+
     parser = make_add_bundles_parser()
     if sysargs:
         args = parser.parse_args(sysargs[1:])
@@ -325,6 +327,8 @@ def add_bundles_main(sysargs=None):
 
 
 def remove_operators_main(sysargs=None):
+    logging.basicConfig(level=logging.INFO)
+
     parser = make_rm_operators_parser()
     if sysargs:
         args = parser.parse_args(sysargs[1:])

--- a/tests/test_iib_ops.py
+++ b/tests/test_iib_ops.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 import mock
 import pkg_resources
 import pytest
@@ -421,6 +422,7 @@ def test_add_bundles_py(
     fixture_container_image_repo,
     fixture_common_iib_op_args,
 ):
+    caplog.set_level(logging.INFO)
     repo = fixture_container_image_repo
     fixture_pulp_client.return_value.search_repository.return_value = [repo]
     fixture_pulp_client.return_value.get_repository.return_value = repo


### PR DESCRIPTION
We now have documented at [1] the preferred logger setup for
projects in the pubtools family. Tweak logger to be consistent with
that, which means:

- our logger should be named "pubtools.iib"
- we should not set the level by default (but basicConfig is OK)

This helps to ensure loggers are configurable consistently across
the projects.

[1] https://release-engineering.github.io/pubtools/devguide.html