### PR TITLE
Add Bandit scanning to pipeline [RHELDST-12094]

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -88,3 +88,31 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
+  bandit-exitzero:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install RPM
+        run: sudo apt-get install -y rpm
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e py3-bandit-exitzero
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install RPM
+        run: sudo apt-get install -y rpm
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e py3-bandit

--- a/tox.ini
+++ b/tox.ini
@@ -93,3 +93,10 @@ deps=pidiff
 skip_install=true
 commands=pidiff pubtools-iib .
 
+[testenv:py3-bandit-exitzero]
+deps = bandit
+commands = bandit -r . -l --exclude './.tox' --exit-zero
+
+[testenv:py3-bandit]
+deps = bandit
+commands = bandit -r . -ll --exclude './.tox'


### PR DESCRIPTION
To enable SAST scanning on this repository, Bandit has been added into
the tox.ini and .github/workflows/tox-tests.yml files.  Two tests are
executed in the pipeline: py3-bandit-exitzero and py3-bandit.

The first scan lists all findings of low severity or higher and always
passes due to the "exit-zero" option.  This will allow tracking of low
severity findings without stopping code from being merged in.

The second scan lists all findings of medium severity or higher and will
fail the pipeline if any issues have been introduced.

To track the overall progress of Bandit enablement on Pub open-source
libraries, see Jira [RHELDST-9236].