### PR TITLE
Drop Python2 support

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -3,22 +3,6 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py27:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Update existing dependencies
-        run: sudo apt-get update -y
-      - name: Install system dependencies
-        run: sudo apt-get install -y libkrb5-dev
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 2.7
-      - name: Install Tox
-        run: pip install tox
-      - name: Run Tox
-        run: tox -e py27 -vv
   py37:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install RPM
-        run: sudo apt-get install -y rpm
+        run: sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install RPM
-        run: sudo apt-get install -y rpm
+        run: sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-six
 setuptools<60.9.0 # remove when https://github.com/pypa/setuptools/issues/3293 is fixed
-pyrsistent<=0.16.0; python_version == '2.7'
 pushcollector
 pubtools-pulp
 iiblib>=5.0.1

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
     author_email="jluza@redhat.com",
     url="https://gitlab.cee.redhat.com/jluza/pubtools-iib",
     classifiers=classifiers,
+    python_requires=">=3.6",
     packages=find_packages(exclude=["tests"]),
     data_files=[],
     install_requires=INSTALL_REQURIES,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py27,
     py37,
     pycodestyle
     coverage
@@ -24,23 +23,11 @@ show-source=True
 statistics=True
 exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,setup.py,docs
 
-[testenv:py27]
-deps=
-    {[py]deps}
-    -c legacy.constraints
-basepython = python2.7
-commands = python -m pytest -v --cov=pubtools --cov-report=html {posargs}
-
 [testenv:py37]
 deps=
     {[py]deps}
 basepython = python3.7
 commands = python -m pytest -v --cov=pubtools --cov-report=html --cov-report=xml {posargs}
-
-[testenv:pypy]
-deps=
-    {[py]deps}
-basepython = pypy
 
 [testenv:pypy3]
 deps=
@@ -78,7 +65,9 @@ deps=
 commands = coverage report --fail-under 98
 
 [testenv:cov-travis]
-passenv = TRAVIS TRAVIS_*
+passenv = 
+    TRAVIS
+    TRAVIS_*
 deps=
     {[py]deps}
     pytest-cov


### PR DESCRIPTION
After Supercharge Pub 3 was delivered, Python 2 support is no longer required in it's dependencies as well. Dropping Python 2 will make the repos easier to maintain and will speed up Tox and Github Actions since some steps can be removed.