### PR TITLE
Pin bandit version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,9 +83,9 @@ skip_install=true
 commands=pidiff pubtools-iib .
 
 [testenv:py3-bandit-exitzero]
-deps = bandit
+deps = bandit<=1.7.5
 commands = bandit -r . -l --exclude './.tox' --exit-zero
 
 [testenv:py3-bandit]
-deps = bandit
+deps = bandit<=1.7.5
 commands = bandit -r . -ll --exclude './.tox'


### PR DESCRIPTION
We pin the version of Bandit SAST tool to make the CI tests more predictable. If we used the latest version available without pinning it, the CI tests could start failing on new Bandit version without any changes in our codebase.

We pin the Bandit version by adding version requirement to tox.ini.