### PR TITLE
Add static typing to pubtools-iib and mypy to CI/CD

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -3,7 +3,7 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py37:
+  py310:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -14,11 +14,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
-        run: tox -e py37 -vv
+        run: tox -e py310 -vv
   pycodestyle:
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -46,11 +46,27 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
         run: tox -e docs -vv
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update existing dependencies
+        run: sudo apt-get update -y
+      - name: Install system dependencies
+        run: sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e mypy -vv
   coverage:
     runs-on: ubuntu-latest
     steps:
@@ -62,11 +78,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
-        run: tox -e py37
+        run: tox -e py310
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.15
         with:
@@ -81,7 +97,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -95,7 +111,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+ignore_missing_imports = True
+strict = True

--- a/pubtools/iib/utils.py
+++ b/pubtools/iib/utils.py
@@ -3,11 +3,12 @@ import contextlib
 import os
 import sys
 import pkg_resources
+from typing import Any
 
 from iiblib import iib_client, iib_authentication
 
 
-def setup_iib_client(parsed_args):
+def setup_iib_client(parsed_args: argparse.Namespace) -> iib_client.IIBClient:
     iib_auth = iib_authentication.IIBKrbAuth(
         parsed_args.iib_krb_principal,
         parsed_args.iib_server,
@@ -22,9 +23,9 @@ def setup_iib_client(parsed_args):
     return iibc
 
 
-def setup_arg_parser(args):
+def setup_arg_parser(args: dict[Any, Any]) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
-    arg_groups = {}
+    arg_groups: dict[Any, Any] = {}
     for aliases, arg_data in args.items():
         holder = parser
         if arg_data["group"]:
@@ -52,7 +53,12 @@ def setup_arg_parser(args):
 
 
 @contextlib.contextmanager
-def setup_entry_point_cli(entry_tuple, name, args, environ_vars):
+def setup_entry_point_cli(
+    entry_tuple: tuple[str, str, str],
+    name: str,
+    args: list[str],
+    environ_vars: dict[str, str],
+) -> Any:
     orig_argv = sys.argv[:]
     orig_environ = os.environ.copy()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
-    py37,
-    pycodestyle
-    coverage
+    py310,
+    pycodestyle,
+    coverage,
     docs,
+    mypy
 
 [testenv]
 commands =
@@ -24,10 +25,10 @@ show-source=True
 statistics=True
 exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,setup.py,docs
 
-[testenv:py37]
+[testenv:py310]
 deps=
     {[py]deps}
-basepython = python3.7
+basepython = python3.10
 commands = python -m pytest -v --cov=pubtools --cov-report=html --cov-report=xml {posargs}
 
 [testenv:pypy3]
@@ -40,17 +41,17 @@ deps=
     {[py]deps}
     pycodestyle
     black
-basepython = python3.7
+basepython = python3.10
 commands =
     pycodestyle --config=.pycodestyle --first pubtools
-	black --check .
+	black --check pubtools
 exclude=.svn,cvs,.bzr,.hg,.git,__pycache__,.tox,setup.py,docs
 
 [testenv:pydocstyle]
 deps=
     pydocstyle
 commands = pydocstyle pubtools
-basepython = python3.7
+basepython = python3.10
 exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,setup.py,docs
 
 [testenv:docs]
@@ -58,12 +59,23 @@ deps=
     Sphinx
     sphinx_rtd_theme
     sphinx-argparse
-commands = python setup.py build_sphinx
+commands = sphinx-build -M html docs/source docs/build
 
 [testenv:coverage]
 deps=
     coverage
 commands = coverage report --fail-under 98
+
+[testenv:mypy]
+description = mypy checks
+basepython = python3.10
+deps =
+    -r requirements.txt
+    types-requests
+    types-setuptools
+    mypy
+commands =
+    mypy pubtools
 
 [testenv:cov-travis]
 passenv = 


### PR DESCRIPTION
The mypy checks pass with strict mode enabled. A somewhat unrelated change is the modernization of pubtools-iib's CI/CD pipeline.

Refers to CLOUDDST-20546