### PR TITLE
Add an argument to set the IIB build timeout

### DIFF
--- a/pubtools/iib/iib_ops.py
+++ b/pubtools/iib/iib_ops.py
@@ -89,6 +89,12 @@ CMD_ARGS = {
         "type": str,
         "action": "append",
     },
+    ("--build-timeout",): {
+        "group": "IIB service",
+        "help": "How long to wait for an IIB build before raising timeout error",
+        "required": False,
+        "type": str,
+    },
 }
 
 ADD_CMD_ARGS = CMD_ARGS.copy()

--- a/pubtools/iib/utils.py
+++ b/pubtools/iib/utils.py
@@ -19,6 +19,8 @@ def setup_iib_client(parsed_args: argparse.Namespace) -> iib_client.IIBClient:
     }
     if parsed_args.iib_insecure:
         kwargs["ssl_verify"] = False
+    if parsed_args.build_timeout:
+        kwargs["wait_for_build_timeout"] = int(parsed_args.build_timeout)
     iibc = iib_client.IIBClient(parsed_args.iib_server, **kwargs)
     return iibc
 

--- a/tests/test_iib_ops.py
+++ b/tests/test_iib_ops.py
@@ -142,7 +142,10 @@ def add_bundles_mock_calls_tester(
         build_tags=["extra-tag-1", "extra-tag-2"],
     )
     fixture_iib_client.assert_called_once_with(
-        "iib-server", auth=fixture_iib_krb_auth.return_value, ssl_verify=False
+        "iib-server",
+        auth=fixture_iib_krb_auth.return_value,
+        ssl_verify=False,
+        wait_for_build_timeout=30,
     )
 
 
@@ -265,7 +268,7 @@ def remove_operators_mock_calls_tester(
             add_bundles_mock_calls_tester_deprecation_bundles,
         ),
         (
-            ["--deprecation-list", "bundle1"],
+            ["--deprecation-list", "bundle1", "--build-timeout", "30"],
             [operator_1_push_item_pending, operator_1_push_item_pushed],
             add_bundles_mock_calls_tester,
         ),


### PR DESCRIPTION
If unset, the default 2 hours will be used.

Refers to CLOUDDST-22586